### PR TITLE
Use JSCover config API over raw arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See: http://searls.github.io/jasmine-maven-plugin/code-coverage.html : replace t
 <plugin>
 	<groupId>ch.digitalfondue.jscover</groupId>
 	<artifactId>jscoverproxy-maven-plugin</artifactId>
-	<version>1.0</version>
+	<version>1.1</version>
 	<executions>
 		<execution>
 			<goals>
@@ -23,11 +23,11 @@ See: http://searls.github.io/jasmine-maven-plugin/code-coverage.html : replace t
 	<configuration>
 		<baseUrl>http://localhost:${jasmine.serverPort}</baseUrl>
 		<outputDir>${project.build.directory}/report/</outputDir>
-		<noInstruments>
-			<noInstrument>webjars/</noInstrument>
-			<noInstrument>classpath/</noInstrument>
-			<noInstrument>spec/</noInstrument>
-		</noInstruments>
+        <instrumentPathArgs>
+            <arg>--no-instrument=webjars/</arg>
+            <arg>--no-instrument=classpath/</arg>
+            <arg>--no-instrument=spec/</arg>
+        </instrumentPathArgs>
 		<jsSrcDir>src/main/webapp/app</jsSrcDir>
 		<generateXMLSUMMARY>true</generateXMLSUMMARY>
 		<generateLCOV>true</generateLCOV>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<dependency>
 			<groupId>com.github.tntim96</groupId>
 			<artifactId>JSCover</artifactId>
-			<version>1.0.25</version>
+			<version>1.0.26-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>


### PR DESCRIPTION
This requires JSCover 1.0.26-SNAPSHOT which I can release when needed.

I've copied some techniques from a similar plugin I wrote, https://github.com/tntim96/JSCover-maven-plugin. I've altered the no-args parameters so it is more flexible, allowing regular expressions and other options which JSCover allows.